### PR TITLE
Fix for keyboard unlock when Windows+L is pressed

### DIFF
--- a/addon/globalPlugins/inputLock.py
+++ b/addon/globalPlugins/inputLock.py
@@ -98,12 +98,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		   not config.conf['inputlock']['blockClicks']:
 			return mouseCallbackFunc(msg, x, y, injected)
 		else:
-			if self.mouseLocked and not self.locked:
+			if  self.mouseLocked and not self.locked:
 				mouseHandler.executeMouseMoveEvent(self.cursorPos[0], self.cursorPos[1])
 			winUser.setCursorPos(self.cursorPos[0], self.cursorPos[1])
 
 	def capture(self, gesture):
-		if gesture.displayName == self.gesture.displayName:
+		if not self.gesture or gesture.displayName == self.gesture.displayName:
 			return True
 		else:
 			return False
@@ -119,6 +119,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		winInputHook.setCallbacks(mouse=mouseCallbackFunc)
 		self.cursorPos = None
 		mouseCallbackFunc = None
+
+	def event_foreground(self, obj, next):
+		try:
+			window = obj.appModule.productName
+		except:
+			window = ""
+		if self.locked and window != 'Microsoft.LockApp':
+			self.prevCaptureFunc = inputCore.manager._captureFunc
+			inputCore.manager._captureFunc = self.capture
+		next()
 
 	def script_inputLock(self, gesture):
 		self.locked = not self.locked


### PR DESCRIPTION
When Windows+L is pressed even though the keyboard is locked, the Windows session is locked and the login window appears. The keyboard is unlocked and remains unlocked on return to the session even though the locked flag is True.

How does fix work?
When the active window changes (event_foreground), it checks if self.lock is True. This combination can only happen if Windows+L is pressed with the keyboard locked.
Keyboard use is allowed in the login window (Microsoft.LockApp). Otherwise the user could be trapped there without being able to get out.
When the password is entered and the windows session is returned, the keyboard is locked again.