### PR TITLE
Add Touchpad Lock/Unlock Feature

### DIFF
--- a/addon/globalPlugins/inputLock.py
+++ b/addon/globalPlugins/inputLock.py
@@ -9,8 +9,8 @@ import ui
 import inputCore
 import mouseHandler
 import winInputHook
-import winreg
 import winUser
+import winreg
 import config
 from gui import guiHelper
 from keyboardHandler import KeyboardInputGesture
@@ -35,6 +35,7 @@ allowedMouseActions = [
 	mouseHandler.WM_RBUTTONUP]
 mouseCallbackFunc = None
 
+
 def getTouchpadStatus():
 	"""
 	Returns the status of the Precision Touchpad.
@@ -43,11 +44,13 @@ def getTouchpadStatus():
 		bool: True if the touchpad is enabled, False if disabled.
 		None: If there's an error accessing the registry.
 	"""
+	path = r"SOFTWARE\Microsoft\Windows\CurrentVersion\PrecisionTouchPad\Status"
 	try:
-		with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\PrecisionTouchPad\Status") as key:
+		with winreg.OpenKey(winreg.HKEY_CURRENT_USER, path) as key:
 			return bool(winreg.QueryValueEx(key, "Enabled")[0])
 	except FileNotFoundError:
 		return None
+
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
@@ -156,9 +159,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		**speakOnDemand)
 	def script_SwitchTouchpad(self, gesture):
 		if getTouchpadStatus() is None:
-			return ui.message(_("not support"))
+			# TRANSLATORS: message spoken when the touchpad lock is not supported
+			ui.message(_("not support"))
+			return
 		KeyboardInputGesture.fromName("windows+control+f24").send()
-		ui.message(_("Touchpad unlocked") if getTouchpadStatus() else _("Touchpad locked"))
+		if getTouchpadStatus():
+			# TRANSLATORS: message spoken when the touchpad is unlocked
+			ui.message(_("Touchpad unlocked"))
+		else:
+			# TRANSLATORS: message spoken when the touchpad is locked
+			ui.message(_("Touchpad locked"))
 
 
 class inputLockPanel(SettingsPanel):

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,15 @@
 
 Do you have kids or pets at home? Do you have a cat and It likes very much climbing your table and walking over your keyboard? Do you accidentally move the mouse to random parts in the screen while using your laptop? Then Input Lock is for you! You will be able to leave your computer alone and turned on without risk.
 
-Once installed, you will be able to lock your keyboard, touch screen, if your laptop has one, mouse and Braille display.
+Once installed, you will be able to lock your keyboard, touch screen (if your laptop has one), touchpad, mouse, and Braille display.
 
 ## Usage
 
-This addon adds two extra gestures to NVDA. By default they are unassigned, so you will have to configure them from Input gestures dialog. Read the NVDA User Guide for more information.
+This addon adds three extra gestures to NVDA. By default they are unassigned, so you will have to configure them from Input gestures dialog. Read the NVDA User Guide for more information.
 
 When you press the toggle input lock gesture, NVDA will say "Input locked". Your input devices will be blocked until you press the same gesture again. In that moment, NVDA will say "Input unlocked" and everything will work as usual.
+
+Locking the touchpad can prevent us from accidentally touching it, especially those who are used to using the laptop keyboard directly. When you press the toggle touchpad lock gesture, NVDA will say "Touchpad locked". Your touchpad will be blocked until you press the same gesture again. In that moment, NVDA will say "Touchpad unlocked" and everything will work as usual.
 
 If you press the toggle mouse block gesture, your mouse will be locked. Press this command again to unlock it. While mouse is locked, you can use NVDA gestures to move it, and click with left and right buttons, but You can't move the mouse itself. Mouse clicks can also be disabled from Input lock category in NVDA settings dialog (NVDA 2018.2 and later) or from add-on settings dialog for older versions, available under preferences menu. In addition, from these settings you can control wether mouse locks when NVDA is started or not.
 
@@ -23,7 +25,7 @@ Note: when mouse clicks are blocked, you can't use any NVDA gestures to work wit
 Input Lock has the following known problems:
 
 * The shortcuts control+alt+del and windows+l can be used even when the keyboard is locked.
-* On some laptops, the touchpad still accepts user input after mouse is blocked.
+* For gestures used to lock the touchpad, please try to assign a small number of key combination gestures. It is recommended to use NVDA+letters or numbers, Ctrl+F keys etc.
 
 ## Changelog
 


### PR DESCRIPTION
Close #7 

## Description:

This PR introduces a new feature to the Input Lock addon, allowing users to toggle the lock status of their touchpad. The implementation is based on Microsoft's documentation on touchpad toggle buttons: [Touchpad toggle button to enable or disable](https://docs.microsoft.com/en-us/windows-hardware/design/component-guidelines/touchpad-toggle-button-to-enable-or-disable).

## Changes:

- Added a new script `script_SwitchTouchpad` to the `GlobalPlugin` class, which toggles the touchpad lock status using the `KeyboardInputGesture.fromName("windows+control+f24").send()` method. This method simulates the key combination that is typically used to toggle the touchpad status on Windows devices.
- Added a new method `getTouchpadStatus` to check the current status of the touchpad by accessing the Windows Registry.
- Added user feedback messages to inform the user whether the touchpad has been locked or unlocked.

## Testing:

The feature has been tested on a Windows 10 device with a precision touchpad. 

## Known issues

Since this requires simulating keystrokes, not all gestures set will work for toggle touchpad lock.  
For example: ``Ctrl+Alt+F4`` I haven't thought of a better way to avoid this problem yet.

I haven't updated the readme yet and I'd like to hear @jmdaweb's suggestions.
